### PR TITLE
updated ARM-none-eabi toolchain to 9-2020-q2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ WORKDIR ${TOOLS_PATH}
 # Install basic programs and custom glibc
 RUN apk --no-cache add ca-certificates wget make cmake stlink \
 	&& wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-	&& wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk \
-	&& apk add glibc-2.29-r0.apk \
-	&& rm glibc-2.29-r0.apk
+	&& wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk \
+	&& apk add glibc-2.32-r0.apk \
+	&& rm glibc-2.32-r0.apk
 
 # Install STM32 toolchain
-ARG TOOLCHAIN_TARBALL_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2"
+ARG TOOLCHAIN_TARBALL_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2"
 ARG TOOLCHAIN_PATH=${TOOLS_PATH}/toolchain
 RUN wget ${TOOLCHAIN_TARBALL_URL} \
 	&& export TOOLCHAIN_TARBALL_FILENAME=$(basename "${TOOLCHAIN_TARBALL_URL}") \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 Lightweight docker image built on top of **alpine:3.10** with installed ARM-none-eabi toolchain and few additional tools:
-* ARM-none-eabi toolchain (2019; GNU Tools for Arm Embedded Processors 8-2019-q3-update)
+* ARM-none-eabi toolchain (2020; GNU Tools for Arm Embedded Processors 9-2020-q2-update)
 * stlink (v1.5)
 * make (v4.2)
 * cmake (v3.14)


### PR DESCRIPTION
Could you also update the dockerhub image, and maybe add versions to the images?