### PR TITLE
fix for toolchain directory name taken from tar archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG TOOLCHAIN_PATH=${TOOLS_PATH}/toolchain
 RUN wget ${TOOLCHAIN_TARBALL_URL} \
 	&& export TOOLCHAIN_TARBALL_FILENAME=$(basename "${TOOLCHAIN_TARBALL_URL}") \
 	&& tar -xvf ${TOOLCHAIN_TARBALL_FILENAME} \
-	&& mv `tar -tf ${TOOLCHAIN_TARBALL_FILENAME} | head -1` ${TOOLCHAIN_PATH} \
+	&& mv $(dirname `tar -tf ${TOOLCHAIN_TARBALL_FILENAME} | head -1`) ${TOOLCHAIN_PATH} \
 	&& rm -rf ${TOOLCHAIN_PATH}/share/doc \
 	&& rm ${TOOLCHAIN_TARBALL_FILENAME}
 


### PR DESCRIPTION
The new toolchain archive has a slightly different directory structure which broke the installation in the first PR.
