### PR TITLE
arm none eabi 7 2018 q2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apk --no-cache add ca-certificates wget make cmake stlink \
 	&& rm glibc-2.29-r0.apk
 
 # Install STM32 toolchain
-#ARG TOOLCHAIN_TARBALL_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2"
 ARG TOOLCHAIN_TARBALL_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2"
 
 ARG TOOLCHAIN_PATH=${TOOLS_PATH}/toolchain

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,14 @@ RUN apk --no-cache add ca-certificates wget make cmake stlink \
 	&& rm glibc-2.29-r0.apk
 
 # Install STM32 toolchain
-ARG TOOLCHAIN_TARBALL_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2"
+#ARG TOOLCHAIN_TARBALL_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2"
+ARG TOOLCHAIN_TARBALL_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2"
+
 ARG TOOLCHAIN_PATH=${TOOLS_PATH}/toolchain
 RUN wget ${TOOLCHAIN_TARBALL_URL} \
 	&& export TOOLCHAIN_TARBALL_FILENAME=$(basename "${TOOLCHAIN_TARBALL_URL}") \
 	&& tar -xvf ${TOOLCHAIN_TARBALL_FILENAME} \
-	&& mv `tar -tf ${TOOLCHAIN_TARBALL_FILENAME} | head -1` ${TOOLCHAIN_PATH} \
+	&& mv $(dirname `tar -tf ${TOOLCHAIN_TARBALL_FILENAME} | head -1`) ${TOOLCHAIN_PATH} \
 	&& rm -rf ${TOOLCHAIN_PATH}/share/doc \
 	&& rm ${TOOLCHAIN_TARBALL_FILENAME}
 


### PR DESCRIPTION
This one uses gcc7 as used in stm32CubeIDE 1.5 as default toolchain.
Can you generate a image on dockerhub with version 7-2018-q2 without rolling back "latest"?