### PR TITLE
Fixed multiple problems with the examples functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ $ stm32-toolchain arm-none-eabi-cpp --version
 $ stm32-toolchain st-flash --version
 $ stm32-toolchain make -version
 $ stm32-toolchain cmake -version
-$ stm32-toolchain cmake -Bbuild
+$ stm32-toolchain cmake -Bbuild .
 $ stm32-toolchain make --directory build
 ```

--- a/README.md
+++ b/README.md
@@ -44,5 +44,6 @@ $ stm32-toolchain arm-none-eabi-cpp --version
 $ stm32-toolchain st-flash --version
 $ stm32-toolchain make -version
 $ stm32-toolchain cmake -version
-$ stm32-toolchain make && make flash
+$ stm32-toolchain cmake -Bbuild
+$ stm32-toolchain make --directory build
 ```


### PR DESCRIPTION
Hi,

The problems were :

- `stm32-toolchain make && make flash` is actually `(stm32-toolchain make) && (make flash)`
- `stm32-toolchain make && make flash` does nothing without a call to cmake first
- `stm32-toolchain make && make flash` building outside a build folder makes cmake sad :D